### PR TITLE
feat: Merge searchResult

### DIFF
--- a/findpapers/core/paper.py
+++ b/findpapers/core/paper.py
@@ -301,6 +301,29 @@ class Paper:
             return self.title.strip().lower()
         return None
 
+    def _title_year_key(self) -> str:
+        """Build a normalised ``title|year`` deduplication key for a paper.
+
+        Used as the pass-1 fallback dedup key when no DOI is available.
+
+        Parameters
+        ----------
+        paper : Paper
+            Paper to key.
+
+        Returns
+        -------
+        str
+            Title/year key string.
+        """
+        title = self.title
+        year = getattr(self.publication_date, "year", None)
+        if title and year:
+            return f"title:{str(title).strip().lower()}|year:{year}"
+        if title:
+            return f"title:{str(title).strip().lower()}"
+        return f"object:{id(self)}"
+
     @staticmethod
     def _normalize_title(title: str) -> str:
         """Strip HTML tags and normalize whitespace in a paper title.

--- a/findpapers/core/search_result.py
+++ b/findpapers/core/search_result.py
@@ -3,12 +3,16 @@
 from __future__ import annotations
 
 import contextlib
+import copy
 import datetime
+import logging
 from typing import Any
 
 from findpapers.core.paper import Paper
 from findpapers.utils.dedup import _are_years_compatible
 from findpapers.utils.version import package_version
+
+logger = logging.getLogger(__name__)
 
 
 class SearchResult:
@@ -71,6 +75,16 @@ class SearchResult:
             runtime_seconds_per_database or {}
         )
         self.failed_databases: list[str] = list(failed_databases or [])
+
+    def copy(self) -> SearchResult:
+        """
+        Create a deep copy of the instance.
+        Returns
+        -------
+        SearchResulg
+            A deep copy of the current instance
+        """
+        return copy.deepcopy(self)
 
     def add_paper(self, paper: Paper) -> None:
         """Add a paper to the results.
@@ -245,9 +259,72 @@ class SearchResult:
 
         self.papers = result
 
-    def _dedupe_key(
-        self, paper: Paper
-    ) -> str | None:  # TODO I think it should be a method of paper
+    def merge_with(self, other: SearchResult | Paper | list[Paper]) -> SearchResult:
+        """
+        Merge the current SearchResult with another SearchResult, paper or list of papers and return a new combined SearchResult.
+
+        Only papers that match the current search filters are included in the merge.
+        Metadata fields are updated accordingly, if no merge can be done the metadata is set to None.
+
+        Parameters
+        ----------
+        other : SearchResult or Paper or list of Paper
+
+        Returns
+        -------
+        SearchResult
+            A new SearchResult instance containing the merged papers, along with updated metadata.
+
+        Raises
+        ------
+        ValueError
+            If `other` is not an instance of SearchResult, Paper, or a list of Paper.
+
+        Examples
+        --------
+        >>> result1 = SearchResult(...)
+        >>> result2 = SearchResult(...)
+        >>> merged = result1.merge_with(result2)
+
+        >>> paper = Paper(...)
+        >>> merged = result1.merge_with(paper)
+
+        >>> papers = [Paper(...), Paper(...)]
+        >>> merged = result1.merge_with(papers)
+        """
+        result = self.copy()
+        if isinstance(other, Paper):
+            if result._matches_filters(other):
+                other_papers = [other]
+            else:
+                logger.warning(
+                    "Paper does not match search result filters, nothing to merge aborting"
+                )
+                return result
+        elif isinstance(other, list):
+            other_papers = [p for p in other if result._matches_filters(p)]
+        elif isinstance(other, SearchResult):
+            other_papers = [p for p in other.papers if result._matches_filters(p)]
+        else:
+            raise ValueError("Invalid type to merge with SearchResult")
+        result.papers += other_papers
+        other_databases = {
+            db for p in other_papers if p.databases is not None for db in p.databases
+        }
+        result._deduplicate_and_merge(metrics={})
+        base_databases = set(self.databases or [])
+        result.databases = list(base_databases.union(other_databases))
+        if (
+            isinstance(other, SearchResult)
+            and other.max_papers_per_database != self.max_papers_per_database
+        ):
+            result.max_papers_per_database = None
+        result.failed_databases = [db for db in self.failed_databases if db not in other_databases]
+        result.runtime_seconds_per_database = {}
+        result.processed_at = datetime.datetime.now(datetime.UTC)
+        return result
+
+    def _dedupe_key(self, paper: Paper) -> str:  # TODO I think it should be a method of paper
         """Build a stable primary deduplication key for a paper.
 
         Uses the DOI when available; otherwise falls back to a normalised
@@ -263,6 +340,32 @@ class SearchResult:
         str
             Dedupe key string.
         """
-        if paper.doi:
-            return paper._identity_key()
+        if paper.doi is not None:
+            return paper.doi
         return paper._title_year_key()
+
+    def _matches_filters(self, paper: Paper) -> bool:
+        """Return ``True`` when *paper* passes all configured date filters.
+
+        Checks the ``since``/``until`` date range.  Any filter that is
+        ``None`` (not configured) is treated as a pass-through.  Papers with
+        no ``publication_date`` are excluded when any date filter is active.
+
+        Parameters
+        ----------
+        paper : Paper
+            Candidate paper to evaluate.
+
+        Returns
+        -------
+        bool
+            ``True`` if the paper satisfies all active filters.
+        """
+        if self.since is not None and (
+            paper.publication_date is None or paper.publication_date < self.since
+        ):
+            return False
+        return not (
+            self.until is not None
+            and (paper.publication_date is None or paper.publication_date > self.until)
+        )

--- a/findpapers/core/search_result.py
+++ b/findpapers/core/search_result.py
@@ -6,8 +6,9 @@ import contextlib
 import datetime
 from typing import Any
 
-from ..utils.version import package_version
-from .paper import Paper
+from findpapers.core.paper import Paper
+from findpapers.utils.dedup import _are_years_compatible
+from findpapers.utils.version import package_version
 
 
 class SearchResult:
@@ -167,3 +168,101 @@ class SearchResult:
             runtime_seconds_per_database=metadata.get("runtime_seconds_per_database"),
             failed_databases=metadata.get("failed_databases"),
         )
+
+    def _deduplicate_and_merge(self, metrics: dict[str, int | float]) -> None:
+        """Collapse duplicate papers in two passes.
+
+        **Pass 1** groups papers by their primary key (DOI when available,
+        otherwise a normalised ``title|year`` string).  This resolves exact
+        duplicates found within the same database or between databases that
+        share the same DOI.
+
+        **Pass 2** groups the results of pass 1 by normalised title and
+        merges entries whose publication years are *compatible* — i.e. they
+        share the same year, at least one has no year (incomplete metadata),
+        or at least one entry carries a preprint DOI and their years differ by
+        at most one (to handle both the case of the same preprint deposited to
+        two servers across the Dec/Jan calendar boundary and the common
+        preprint-to-published transition, e.g. Zenodo 2026 + book chapter
+        2025).  Papers with the same title and *different known years* where
+        neither is from a preprint server are intentionally kept separate.
+
+        This correctly handles the common cross-database case where the same
+        work is indexed with different DOIs (e.g. an arXiv preprint DOI vs a
+        publisher DOI) and one of the database records lacks a publication
+        date.
+
+        When two papers are deemed duplicates their data is merged using
+        :meth:`~findpapers.core.paper.Paper.merge` (most-complete strategy).
+
+        Parameters
+        ----------
+        metrics : dict[str, int | float]
+            Metrics dict (currently unused; reserved for future statistics).
+
+        Returns
+        -------
+        None
+        """
+        # Pass 1: primary key dedup (DOI > title|year > title).
+        pass1: dict[str, Paper] = {}
+        for paper in self.papers:
+            key = self._dedupe_key(paper)
+            if key in pass1:
+                pass1[key].merge(paper)
+            else:
+                pass1[key] = paper
+
+        # Pass 2: title-based dedup that handles missing year metadata.
+        # Group survivors from pass 1 by normalised title, then within each
+        # title group greedily merge papers whose years are compatible.
+        by_title: dict[str, list[Paper]] = {}
+        untitled: list[Paper] = []
+        for paper in pass1.values():
+            norm_title = paper.title.strip().lower() if paper.title else ""
+            if norm_title:
+                by_title.setdefault(norm_title, []).append(paper)
+            else:
+                untitled.append(paper)
+
+        result: list[Paper] = list(untitled)
+        for candidates in by_title.values():
+            # Greedily merge into the first compatible representative.
+            groups: list[Paper] = []
+            for paper in candidates:
+                paper_year = getattr(paper.publication_date, "year", None)
+                merged_into: Paper | None = None
+                for representative in groups:
+                    rep_year = getattr(representative.publication_date, "year", None)
+                    if _are_years_compatible(rep_year, paper_year, representative.doi, paper.doi):
+                        merged_into = representative
+                        break
+                if merged_into is not None:
+                    merged_into.merge(paper)
+                else:
+                    groups.append(paper)
+            result.extend(groups)
+
+        self.papers = result
+
+    def _dedupe_key(
+        self, paper: Paper
+    ) -> str | None:  # TODO I think it should be a method of paper
+        """Build a stable primary deduplication key for a paper.
+
+        Uses the DOI when available; otherwise falls back to a normalised
+        ``title|year`` combination.
+
+        Parameters
+        ----------
+        paper : Paper
+            Paper to key.
+
+        Returns
+        -------
+        str
+            Dedupe key string.
+        """
+        if paper.doi:
+            return paper._identity_key()
+        return paper._title_year_key()

--- a/findpapers/runners/search_runner.py
+++ b/findpapers/runners/search_runner.py
@@ -22,33 +22,6 @@ from findpapers.utils.progress import make_progress_bar
 
 logger = logging.getLogger(__name__)
 
-_PREPRINT_DOI_PREFIXES: frozenset[str] = frozenset(
-    {
-        "10.48550/arxiv.",  # arXiv
-        "10.1101/",  # bioRxiv / medRxiv
-        "10.2139/ssrn.",  # SSRN
-        "10.5281/zenodo.",  # Zenodo
-        "10.20944/preprints",  # Preprints.org
-    }
-)
-
-
-def _is_preprint_doi(doi: str) -> bool:
-    """Return ``True`` when *doi* belongs to a preprint server.
-
-    Parameters
-    ----------
-    doi : str
-        DOI string (without ``https://doi.org/`` prefix).
-
-    Returns
-    -------
-    bool
-        ``True`` for known preprint-server DOI prefixes.
-    """
-    lowered = doi.strip().lower()
-    return any(lowered.startswith(prefix) for prefix in _PREPRINT_DOI_PREFIXES)
-
 
 class SearchRunner(DiscoveryRunner):
     """Public API entry point for running academic paper searches.
@@ -288,31 +261,41 @@ class SearchRunner(DiscoveryRunner):
             for searcher in self._searchers:
                 searcher.close()
 
+        self._search = SearchResult(
+            query=self._query_string,
+            max_papers_per_database=self._max_papers_per_database,
+            processed_at=datetime.now(UTC),
+            databases=[s.name for s in self._searchers],
+            papers=list(self._results),
+            runtime_seconds=None,
+            runtime_seconds_per_database=db_runtimes or None,
+            since=self._since,
+            until=self._until,
+            failed_databases=failed_databases or None,
+        )
         before_dedupe = len(self._results)
-        self._deduplicate_and_merge(metrics)
+        self._search._deduplicate_and_merge(metrics)
         if verbose:
-            merged = before_dedupe - len(self._results)
+            merged = before_dedupe - len(self._search.papers)
             logger.info(
                 "Dedupe: %d -> %d papers (%d merged)",
                 before_dedupe,
                 len(self._results),
                 merged,
             )
-
         # Apply post-fetch date filters.  Connectors that only support
         # year-level date filtering may return papers outside the requested
         # range; _matches_filters enforces precise boundaries.
         if self._since is not None or self._until is not None:
-            before_filter = len(self._results)
-            self._results = [p for p in self._results if self._matches_filters(p)]
+            before_filter = len(self._search.papers)
+            self._search.papers = [p for p in self._search.papers if self._matches_filters(p)]
             if verbose:
                 logger.info(
                     "Post-fetch filter: %d -> %d papers (%d removed)",
                     before_filter,
-                    len(self._results),
-                    before_filter - len(self._results),
+                    len(self._search.papers),
+                    before_filter - len(self._search.papers),
                 )
-
         # Enrich the filtered papers via per-paper get() lookups.
         # enrichment_databases=None  → enrich with all available databases.
         # enrichment_databases=[]    → skip enrichment entirely.
@@ -320,13 +303,12 @@ class SearchRunner(DiscoveryRunner):
             isinstance(self._enrichment_databases, list) and len(self._enrichment_databases) == 0
         ):
             super()._enrich_papers(
-                self._results,
+                self._search.papers,
                 verbose,
                 show_progress=show_progress,
                 num_workers=self._num_workers,
             )
-
-        metrics["total_papers"] = len(self._results)
+        metrics["total_papers"] = len(self._search.papers)
         metrics["runtime_in_seconds"] = perf_counter() - start
         self._metrics = metrics
 
@@ -337,19 +319,9 @@ class SearchRunner(DiscoveryRunner):
             for searcher in self._searchers:
                 count = int(metrics.get(f"total_papers_from_{searcher.name}", 0))
                 logger.info("  %s: %d papers", searcher.name, count)
-
-        self._search = SearchResult(
-            query=self._query_string,
-            max_papers_per_database=self._max_papers_per_database,
-            processed_at=datetime.now(UTC),
-            databases=[s.name for s in self._searchers],
-            papers=list(self._results),
-            runtime_seconds=self._metrics.get("runtime_in_seconds"),
-            runtime_seconds_per_database=db_runtimes or None,
-            since=self._since,
-            until=self._until,
-            failed_databases=failed_databases or None,
-        )
+        # Update of search attributes
+        self._search.runtime_seconds = self._metrics.get("runtime_in_seconds")
+        self._search.processed_at = datetime.now(UTC)
         _root_logger.setLevel(_saved_log_level)
         return self._search
 
@@ -576,170 +548,3 @@ class SearchRunner(DiscoveryRunner):
                 pbar.close()
 
         return failed, db_runtimes
-
-    def _deduplicate_and_merge(self, metrics: dict[str, int | float]) -> None:
-        """Collapse duplicate papers in two passes.
-
-        **Pass 1** groups papers by their primary key (DOI when available,
-        otherwise a normalised ``title|year`` string).  This resolves exact
-        duplicates found within the same database or between databases that
-        share the same DOI.
-
-        **Pass 2** groups the results of pass 1 by normalised title and
-        merges entries whose publication years are *compatible* — i.e. they
-        share the same year, at least one has no year (incomplete metadata),
-        or at least one entry carries a preprint DOI and their years differ by
-        at most one (to handle both the case of the same preprint deposited to
-        two servers across the Dec/Jan calendar boundary and the common
-        preprint-to-published transition, e.g. Zenodo 2026 + book chapter
-        2025).  Papers with the same title and *different known years* where
-        neither is from a preprint server are intentionally kept separate.
-
-        This correctly handles the common cross-database case where the same
-        work is indexed with different DOIs (e.g. an arXiv preprint DOI vs a
-        publisher DOI) and one of the database records lacks a publication
-        date.
-
-        When two papers are deemed duplicates their data is merged using
-        :meth:`~findpapers.core.paper.Paper.merge` (most-complete strategy).
-
-        Parameters
-        ----------
-        metrics : dict[str, int | float]
-            Metrics dict (currently unused; reserved for future statistics).
-
-        Returns
-        -------
-        None
-        """
-        # Pass 1: primary key dedup (DOI > title|year > title).
-        pass1: dict[str, Paper] = {}
-        for paper in self._results:
-            key = self._dedupe_key(paper)
-            if key in pass1:
-                pass1[key].merge(paper)
-            else:
-                pass1[key] = paper
-
-        # Pass 2: title-based dedup that handles missing year metadata.
-        # Group survivors from pass 1 by normalised title, then within each
-        # title group greedily merge papers whose years are compatible.
-        by_title: dict[str, list[Paper]] = {}
-        untitled: list[Paper] = []
-        for paper in pass1.values():
-            norm_title = paper.title.strip().lower() if paper.title else ""
-            if norm_title:
-                by_title.setdefault(norm_title, []).append(paper)
-            else:
-                untitled.append(paper)
-
-        result: list[Paper] = list(untitled)
-        for candidates in by_title.values():
-            # Greedily merge into the first compatible representative.
-            groups: list[Paper] = []
-            for paper in candidates:
-                paper_year = getattr(paper.publication_date, "year", None)
-                merged_into: Paper | None = None
-                for representative in groups:
-                    rep_year = getattr(representative.publication_date, "year", None)
-                    if _are_years_compatible(rep_year, paper_year, representative.doi, paper.doi):
-                        merged_into = representative
-                        break
-                if merged_into is not None:
-                    merged_into.merge(paper)
-                else:
-                    groups.append(paper)
-            result.extend(groups)
-
-        self._results = result
-
-    def _dedupe_key(self, paper: Paper) -> str:
-        """Build a stable primary deduplication key for a paper.
-
-        Uses the DOI when available; otherwise falls back to a normalised
-        ``title|year`` combination.
-
-        Parameters
-        ----------
-        paper : Paper
-            Paper to key.
-
-        Returns
-        -------
-        str
-            Dedupe key string.
-        """
-        if paper.doi:
-            return f"doi:{str(paper.doi).strip().lower()}"
-        return self._title_year_key(paper)
-
-    def _title_year_key(self, paper: Paper) -> str:
-        """Build a normalised ``title|year`` deduplication key for a paper.
-
-        Used as the pass-1 fallback dedup key when no DOI is available.
-        Two records without a DOI but with the same title and the same year
-        are considered identical and are merged in pass 1.
-
-        Parameters
-        ----------
-        paper : Paper
-            Paper to key.
-
-        Returns
-        -------
-        str
-            Title/year key string.
-        """
-        title = paper.title
-        year = getattr(paper.publication_date, "year", None)
-        if title and year:
-            return f"title:{str(title).strip().lower()}|year:{year}"
-        if title:
-            return f"title:{str(title).strip().lower()}"
-        return f"object:{id(paper)}"
-
-
-def _are_years_compatible(
-    year_a: int | None,
-    year_b: int | None,
-    doi_a: str | None,
-    doi_b: str | None,
-) -> bool:
-    """Return whether two publication years are compatible for merging.
-
-    Two papers are considered year-compatible when:
-
-    * Either year is unknown (``None``), or
-    * Both years are identical, or
-    * Their years differ by exactly 1 **and** at least one DOI belongs to a
-      preprint server (covers preprint-to-published transitions across the
-      Dec/Jan boundary).
-
-    Parameters
-    ----------
-    year_a : int | None
-        Publication year of the first paper.
-    year_b : int | None
-        Publication year of the second paper.
-    doi_a : str | None
-        DOI of the first paper.
-    doi_b : str | None
-        DOI of the second paper.
-
-    Returns
-    -------
-    bool
-        ``True`` when the years are compatible for merging.
-    """
-    if year_a is None or year_b is None or year_a == year_b:
-        return True
-
-    # Adjacent-year preprint check.
-    raw_doi_a = doi_a or ""
-    raw_doi_b = doi_b or ""
-    return (
-        abs(year_a - year_b) == 1
-        and bool(raw_doi_a)
-        and bool(raw_doi_b)
-        and (_is_preprint_doi(raw_doi_a) or _is_preprint_doi(raw_doi_b))
-    )

--- a/findpapers/utils/dedup.py
+++ b/findpapers/utils/dedup.py
@@ -1,0 +1,72 @@
+_PREPRINT_DOI_PREFIXES: frozenset[str] = frozenset(
+    {
+        "10.48550/arxiv.",  # arXiv
+        "10.1101/",  # bioRxiv / medRxiv
+        "10.2139/ssrn.",  # SSRN
+        "10.5281/zenodo.",  # Zenodo
+        "10.20944/preprints",  # Preprints.org
+    }
+)
+
+
+def _is_preprint_doi(doi: str) -> bool:
+    """Return ``True`` when *doi* belongs to a preprint server.
+
+    Parameters
+    ----------
+    doi : str
+        DOI string (without ``https://doi.org/`` prefix).
+
+    Returns
+    -------
+    bool
+        ``True`` for known preprint-server DOI prefixes.
+    """
+    lowered = doi.strip().lower()
+    return any(lowered.startswith(prefix) for prefix in _PREPRINT_DOI_PREFIXES)
+
+
+def _are_years_compatible(
+    year_a: int | None,
+    year_b: int | None,
+    doi_a: str | None,
+    doi_b: str | None,
+) -> bool:
+    """Return whether two publication years are compatible for merging.
+
+    Two papers are considered year-compatible when:
+
+    * Either year is unknown (``None``), or
+    * Both years are identical, or
+    * Their years differ by exactly 1 **and** at least one DOI belongs to a
+      preprint server (covers preprint-to-published transitions across the
+      Dec/Jan boundary).
+
+    Parameters
+    ----------
+    year_a : int | None
+        Publication year of the first paper.
+    year_b : int | None
+        Publication year of the second paper.
+    doi_a : str | None
+        DOI of the first paper.
+    doi_b : str | None
+        DOI of the second paper.
+
+    Returns
+    -------
+    bool
+        ``True`` when the years are compatible for merging.
+    """
+    if year_a is None or year_b is None or year_a == year_b:
+        return True
+
+    # Adjacent-year preprint check.
+    raw_doi_a = doi_a or ""
+    raw_doi_b = doi_b or ""
+    return (
+        abs(year_a - year_b) == 1
+        and bool(raw_doi_a)
+        and bool(raw_doi_b)
+        and (_is_preprint_doi(raw_doi_a) or _is_preprint_doi(raw_doi_b))
+    )

--- a/tests/unit/core/test_search_result.py
+++ b/tests/unit/core/test_search_result.py
@@ -6,7 +6,8 @@ import datetime
 
 import pytest
 
-from findpapers.core.paper import Database
+from findpapers.core.author import Author
+from findpapers.core.paper import Database, Paper
 from findpapers.core.search_result import SearchResult
 from findpapers.core.source import Source
 
@@ -244,3 +245,230 @@ class TestFailedDatabases:
         """Older saves without the key produce an empty list."""
         sr = SearchResult.from_dict({"metadata": {}, "papers": []})
         assert sr.failed_databases == []
+
+
+# ---------------------------------------------------------------------------
+# Deduplication and Merge
+# ---------------------------------------------------------------------------
+
+
+class TestMerge:
+    """Test for deduplication and Merge"""
+
+    def test_deduplication_merges_same_doi(self, make_paper):
+        """Two papers with the same DOI are merged into one."""
+        sr = SearchResult(query="[q]")
+        p1 = make_paper(title="Paper A", doi="10.1234/test")
+        sr.add_paper(p1)
+        p2 = make_paper(title="Paper B", doi="10.1234/test")
+        sr.add_paper(p2)
+        sr._deduplicate_and_merge(metrics={})
+        assert len(sr.papers) == 1
+
+    def test_deduplication_keeps_different_dois(self, make_paper):
+        """Papers with different DOIs *and* different titles are kept separately."""
+        sr = SearchResult(query="[q]")
+        p1 = make_paper(title="Paper A", doi="10.1234/aaa")
+        sr.add_paper(p1)
+        p2 = make_paper(title="Paper B", doi="10.1234/bbb")
+        sr.add_paper(p2)
+        sr._deduplicate_and_merge(metrics={})
+        assert len(sr.papers) == 2
+
+    def test_deduplication_second_pass_merges_same_title_different_doi(self, make_paper):
+        """Pass 2 merges papers with the same title even when DOIs differ.
+
+        This covers the common cross-database case where the same work is
+        indexed with an arXiv DOI in one database and the publisher DOI in
+        another (e.g. ``10.48550/arxiv.1706.03762`` vs ``10.5555/3295222.3295349``
+        for "Attention is All You Need").
+        """
+        sr = SearchResult(query="[q]")
+        p1 = make_paper(title="Attention is All You Need", doi="10.48550/arxiv.1706.03762")
+        sr.add_paper(p1)
+        p2 = make_paper(title="Attention is All You Need", doi="10.5555/3295222.3295349")
+        sr.add_paper(p2)
+        sr._deduplicate_and_merge(metrics={})
+        assert len(sr.papers) == 1
+
+    def test_deduplication_second_pass_merges_same_title_one_without_year(self):
+        """Pass 2 merges same-title papers when one lacks a publication date.
+
+        This is the canonical cross-database case: a preprint indexed by
+        arXiv may carry a publication date while the same work indexed by
+        OpenAlex (or another database) has no publication_date in its record.
+        The two copies must be merged rather than kept as separate duplicates.
+        """
+        sr = SearchResult(query="[q]")
+        p1 = Paper(
+            title="Attention is All You Need",
+            abstract="abstract with year",
+            authors=[Author(name="Vaswani et al.")],
+            source=Source(title="arXiv"),
+            publication_date=datetime.date(2017, 6, 12),
+            url="http://arxiv.org/abs/1706.03762",
+            doi="10.48550/arxiv.1706.03762",
+        )
+        sr.add_paper(p1)
+        p2 = Paper(
+            title="Attention is All You Need",
+            abstract="abstract without year",
+            authors=[Author(name="Vaswani et al.")],
+            source=Source(title="OpenAlex Source"),
+            publication_date=None,  # intentionally missing
+            url="http://openalex.org/W2963403868",
+            doi="10.5555/3295222.3295349",
+        )
+        sr.add_paper(p2)
+        sr._deduplicate_and_merge(metrics={})
+        assert len(sr.papers) == 1
+
+    def test_deduplication_second_pass_keeps_same_title_different_year(self):
+        """Papers with the same title but different publication years are kept separate."""
+        sr = SearchResult(query="[q]")
+        p1 = Paper(
+            title="Annual Report on AI",
+            abstract="abstract",
+            authors=[Author(name="A")],
+            source=Source(title="Journal"),
+            publication_date=datetime.date(2022, 1, 1),
+            url="http://example.com/2022",
+            doi="10.1234/ai-2022",
+        )
+        sr.add_paper(p1)
+        p2 = Paper(
+            title="Annual Report on AI",
+            abstract="abstract",
+            authors=[Author(name="A")],
+            source=Source(title="Journal"),
+            publication_date=datetime.date(2023, 1, 1),
+            url="http://example.com/2023",
+            doi="10.1234/ai-2023",
+        )
+        sr.add_paper(p2)
+        sr._deduplicate_and_merge(metrics={})
+        assert len(sr.papers) == 2
+
+    def test_deduplication_second_pass_merges_preprints_across_year_boundary(self):
+        """Same preprint on two servers across Dec/Jan boundary is merged into one.
+
+        This is the canonical Zenodo+SSRN cross-year scenario: a preprint
+        deposited to Zenodo on 2025-12-25 and mirrored to SSRN on 2026-01-01
+        receives different DOIs from each platform.  After pass 1 both entries
+        survive (different DOIs).  Pass 2 must detect that (a) both DOIs are
+        preprint DOIs and (b) the years differ by exactly 1, and therefore
+        merge them rather than reporting a duplicate title.
+        """
+        sr = SearchResult(query="[q]")
+        p1 = Paper(
+            title="Attention is All You Need... Unless You Are a CISO",
+            abstract="abstract from zenodo",
+            authors=[Author(name="Author A")],
+            source=Source(title="Zenodo"),
+            publication_date=datetime.date(2025, 12, 25),
+            url="https://zenodo.org/records/18056028",
+            doi="10.5281/zenodo.18056028",
+        )
+        sr.add_paper(p1)
+        p2 = Paper(
+            title="Attention is All You Need... Unless You Are a CISO",
+            abstract="abstract from ssrn",
+            authors=[Author(name="Author A")],
+            source=Source(title="SSRN"),
+            publication_date=datetime.date(2026, 1, 1),
+            url="https://ssrn.com/abstract=5967774",
+            doi="10.2139/ssrn.5967774",
+        )
+        sr.add_paper(p2)
+        sr._deduplicate_and_merge(metrics={})
+        assert len(sr.papers) == 1
+
+    def test_deduplication_second_pass_merges_preprint_with_published_version(self):
+        """Preprint DOI + publisher DOI with adjacent years are merged into one.
+
+        The common "preprint-to-published" case: a Zenodo deposit from 2026
+        and a book chapter from 2025 share the same title.  Only the Zenodo
+        record is a preprint, but that is sufficient for the year-adjacent rule
+        to fire — the old ``both_preprints`` requirement was too strict and
+        left such pairs as false duplicates.
+        """
+        sr = SearchResult(query="[q]")
+        p1 = Paper(
+            title="Attention is All You Need",
+            abstract="preprint version",
+            authors=[Author(name="Vaswani et al.")],
+            source=Source(title="Zenodo"),
+            publication_date=datetime.date(2026, 1, 17),
+            url="https://zenodo.org/records/18289747",
+            doi="10.5281/zenodo.18289747",
+        )
+        sr.add_paper(p1)
+        p2 = Paper(
+            title="Attention Is All You Need",
+            abstract="book chapter version",
+            authors=[Author(name="Vaswani et al.")],
+            source=Source(title="Deep Learning Book"),
+            publication_date=datetime.date(2025, 10, 31),
+            url="https://doi.org/10.1201/9781003561460-19",
+            doi="10.1201/9781003561460-19",
+        )
+        sr.add_paper(p2)
+        sr._deduplicate_and_merge(metrics={})
+        assert len(sr.papers) == 1
+
+    def test_deduplication_second_pass_keeps_non_preprint_adjacent_years(self):
+        """Two non-preprint papers with same title and adjacent years are kept separate.
+
+        If neither DOI is a preprint, the year-adjacent rule must NOT fire —
+        annual reports and series papers with consecutive-year DOIs are
+        intentionally distinct entries.
+        """
+        sr = SearchResult(query="[q]")
+        p1 = Paper(
+            title="Annual Report on AI",
+            abstract="abstract",
+            authors=[Author(name="A")],
+            source=Source(title="Journal"),
+            publication_date=datetime.date(2022, 1, 1),
+            url="http://example.com/2022",
+            doi="10.1234/ai-2022",
+        )
+        sr.add_paper(p1)
+        p2 = Paper(
+            title="Annual Report on AI",
+            abstract="abstract",
+            authors=[Author(name="A")],
+            source=Source(title="Journal"),
+            publication_date=datetime.date(2023, 1, 1),
+            url="http://example.com/2023",
+            doi="10.1234/ai-2023",
+        )
+        sr.add_paper(p2)
+        sr._deduplicate_and_merge(metrics={})
+        assert len(sr.papers) == 2
+
+    def test_deduplication_second_pass_keeps_preprints_with_large_year_gap(self):
+        """Preprints with the same title but years >1 apart are kept separate."""
+        sr = SearchResult(query="[q]")
+        p1 = Paper(
+            title="Survey of Transformers",
+            abstract="abstract 2022",
+            authors=[Author(name="Author A")],
+            source=Source(title="Zenodo"),
+            publication_date=datetime.date(2022, 1, 1),
+            url="https://zenodo.org/records/1",
+            doi="10.5281/zenodo.1",
+        )
+        sr.add_paper(p1)
+        p2 = Paper(
+            title="Survey of Transformers",
+            abstract="abstract 2024",
+            authors=[Author(name="Author B")],
+            source=Source(title="arXiv"),
+            publication_date=datetime.date(2024, 6, 1),
+            url="https://arxiv.org/abs/2406.00001",
+            doi="10.48550/arxiv.2406.00001",
+        )
+        sr.add_paper(p2)
+        sr._deduplicate_and_merge(metrics={})
+        assert len(sr.papers) == 2

--- a/tests/unit/core/test_search_result.py
+++ b/tests/unit/core/test_search_result.py
@@ -248,12 +248,12 @@ class TestFailedDatabases:
 
 
 # ---------------------------------------------------------------------------
-# Deduplication and Merge
+# Deduplication
 # ---------------------------------------------------------------------------
 
 
-class TestMerge:
-    """Test for deduplication and Merge"""
+class TestDeduplication:
+    """Test for deduplication"""
 
     def test_deduplication_merges_same_doi(self, make_paper):
         """Two papers with the same DOI are merged into one."""
@@ -472,3 +472,162 @@ class TestMerge:
         sr.add_paper(p2)
         sr._deduplicate_and_merge(metrics={})
         assert len(sr.papers) == 2
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+
+
+class TestMerge:
+    """Test for merge"""
+
+    def test_merge_paper_same_doi(self, make_paper):
+        """Two papers with the same DOI are merged into one."""
+        sr1 = SearchResult(query="[q]")
+        p1 = make_paper(title="Paper A", doi="10.1234/test")
+        sr1.add_paper(p1)
+        p2 = make_paper(title="Paper B", doi="10.1234/test")
+        result = sr1.merge_with(p2)
+        assert len(result.papers) == 1
+
+    def test_merge_searchresult_keeps_different_dois(self, make_paper):
+        """Papers with different DOIs *and* different titles are kept separately."""
+        sr1 = SearchResult(query="[q]")
+        p1 = make_paper(title="Paper A", doi="10.1234/aaa")
+        sr1.add_paper(p1)
+        sr2 = SearchResult(query="[q]")
+        p2 = make_paper(title="Paper B", doi="10.1234/bbb")
+        sr2.add_paper(p2)
+        result = sr1.merge_with(sr2)
+        assert len(result.papers) == 2
+
+    def test_merge_paperlist_same_title_different_doi_different_year(self, make_paper):
+        """Pass 2 merges papers with the same title even when DOIs differ.
+
+        This covers the common cross-database case where the same work is
+        indexed with an arXiv DOI in one database and the publisher DOI in
+        another (e.g. ``10.48550/arxiv.1706.03762`` vs ``10.5555/3295222.3295349``
+        for "Attention is All You Need").
+        """
+        sr = SearchResult(query="[q]")
+        p1 = make_paper(title="Attention is All You Need", doi="10.48550/arxiv.1706.03762")
+        sr.add_paper(p1)
+        p2 = make_paper(title="Attention is All You Need", doi="10.5555/3295222.3295349")
+        p3 = make_paper(title="Annual Report on AI", doi="10.1234/ai-2022")
+        result = sr.merge_with([p2, p3])
+        assert len(result.papers) == 2
+
+    def test_databases_merged(self):
+        """Databases of the result is the merge of all the databases"""
+        sr = SearchResult(query="[q]", databases=['Zenodo'])
+        p1 = Paper(
+            title="Paper 1",
+            abstract="abstract 2022",
+            authors=[Author(name="Author A")],
+            source=Source(title="Zenodo"),
+            databases={'Zenodo'},
+            publication_date=datetime.date(2022, 1, 1),
+            url="https://zenodo.org/records/1",
+            doi="10.1234/zenodo.1",
+        )
+        sr.add_paper(p1)
+        p2 = Paper(
+            title="Paper 2",
+            abstract="abstract 2024",
+            authors=[Author(name="Author B")],
+            source=Source(title="arXiv"),
+            databases={'arXiv'},
+            publication_date=datetime.date(2024, 6, 1),
+            url="https://arxiv.org/abs/2406.00001",
+            doi="10.1234/arxiv.2406.00001",
+        )
+        result = sr.merge_with(p2)
+        assert result.databases is not None
+        assert set(result.databases) == {"arXiv", "Zenodo"}
+
+    def test_max_papers_per_database_mismatch(self):
+        """max_papers_per_database does not match will be set to None"""
+        sr1 = SearchResult(query="[q]", max_papers_per_database=10)
+        p1 = Paper(
+            title="Paper 1",
+            abstract="abstract 2022",
+            authors=[Author(name="Author A")],
+            source=Source(title="arXiv"),
+            publication_date=datetime.date(2022, 1, 1),
+            url="https://zenodo.org/records/1",
+            doi="10.1234/zenodo.1",
+        )
+        sr1.add_paper(p1)
+        sr2 = SearchResult(query="[q]", max_papers_per_database=5)
+        p2 = Paper(
+            title="Paper 1",
+            abstract="abstract 2022",
+            authors=[Author(name="Author A")],
+            source=Source(title="arXiv"),
+            publication_date=datetime.date(2022, 1, 1),
+            url="https://zenodo.org/records/1",
+            doi="10.1234/zenodo.1",
+        )
+        sr2.add_paper(p2)
+        result = sr1.merge_with(sr2)
+        assert result.max_papers_per_database is None
+
+    def test_max_papers_per_database_match(self):
+        """max_papers_per_database does  match will be kept"""
+        sr1 = SearchResult(query="[q]", max_papers_per_database=10)
+        p1 = Paper(
+            title="Paper 1",
+            abstract="abstract 2022",
+            authors=[Author(name="Author A")],
+            source=Source(title="arXiv"),
+            publication_date=datetime.date(2022, 1, 1),
+            url="https://zenodo.org/records/1",
+            doi="10.1234/zenodo.1",
+        )
+        sr1.add_paper(p1)
+        sr2 = SearchResult(query="[q]", max_papers_per_database=10)
+        p2 = Paper(
+            title="Paper 1",
+            abstract="abstract 2022",
+            authors=[Author(name="Author A")],
+            source=Source(title="arXiv"),
+            publication_date=datetime.date(2022, 1, 1),
+            url="https://zenodo.org/records/1",
+            doi="10.1234/zenodo.1",
+        )
+        sr2.add_paper(p2)
+        result = sr1.merge_with(sr2)
+        assert result.max_papers_per_database == 10
+
+    def test_failed_databases_filtered(self):
+        """failed_databases is updated because a paper was added"""
+        sr = SearchResult(
+            query="[q]",
+            databases=["arXiv", "Pubmed", "wos"],
+            failed_databases=["arXiv", "Pubmed", "wos"],
+        )
+        p1 = Paper(
+            title="Paper 1",
+            abstract="abstract 2022",
+            authors=[Author(name="Author A")],
+            source=Source(title="arXiv"),
+            databases={'arXiv'},
+            publication_date=datetime.date(2022, 1, 1),
+            url="https://zenodo.org/records/1",
+            doi="10.1234/zenodo.1",
+        )
+        result = sr.merge_with(p1)
+        assert result.failed_databases == ["Pubmed", "wos"]
+
+    def test_runtime_and_processed_at_updated(self, make_paper):
+        """Test metadata automatic update"""
+        sr1 = SearchResult(query="[q]")
+        p1 = make_paper(title="Paper A", doi="10.1234/aaa")
+        sr1.add_paper(p1)
+        sr2 = SearchResult(query="[q]")
+        p2 = make_paper(title="Paper B", doi="10.1234/bbb")
+        sr2.add_paper(p2)
+        result = sr1.merge_with(sr2)
+        assert result.runtime_seconds_per_database == {}
+        assert result.processed_at is not None

--- a/tests/unit/runners/test_search_runner.py
+++ b/tests/unit/runners/test_search_runner.py
@@ -14,7 +14,7 @@ from findpapers.core.paper import Database, Paper
 from findpapers.core.search_result import SearchResult
 from findpapers.core.source import Source
 from findpapers.exceptions import InvalidParameterError, QueryValidationError, UnsupportedQueryError
-from findpapers.runners.search_runner import SearchRunner, _are_years_compatible, _is_preprint_doi
+from findpapers.runners.search_runner import SearchRunner
 
 
 @pytest.fixture(autouse=True)
@@ -691,72 +691,6 @@ class TestSearchRunnerFailedDatabases:
         result = runner.run()
         assert result.failed_databases == [Database.IEEE]
         assert len(result.papers) == 1
-
-
-# ---------------------------------------------------------------------------
-# _are_years_compatible
-# ---------------------------------------------------------------------------
-
-
-class TestAreYearsCompatible:
-    """Tests for the extracted _are_years_compatible helper."""
-
-    def test_same_year_compatible(self) -> None:
-        """Identical years are always compatible."""
-        assert _are_years_compatible(2025, 2025, None, None) is True
-
-    def test_none_year_a_compatible(self) -> None:
-        """Unknown year_a makes pair compatible."""
-        assert _are_years_compatible(None, 2025, None, None) is True
-
-    def test_none_year_b_compatible(self) -> None:
-        """Unknown year_b makes pair compatible."""
-        assert _are_years_compatible(2025, None, None, None) is True
-
-    def test_both_none_compatible(self) -> None:
-        """Both years unknown is compatible."""
-        assert _are_years_compatible(None, None, None, None) is True
-
-    def test_different_years_no_doi_incompatible(self) -> None:
-        """Different years without DOIs are not compatible."""
-        assert _are_years_compatible(2024, 2025, None, None) is False
-
-    def test_different_years_non_preprint_doi_incompatible(self) -> None:
-        """Different years with non-preprint DOIs are not compatible."""
-        assert _are_years_compatible(2024, 2025, "10.1038/x", "10.1016/y") is False
-
-    def test_adjacent_year_preprint_doi_compatible(self) -> None:
-        """Adjacent years with a preprint DOI (arXiv) are compatible."""
-        assert _are_years_compatible(2025, 2026, "10.48550/arXiv.123", "10.1038/x") is True
-
-    def test_two_year_gap_preprint_incompatible(self) -> None:
-        """Years separated by >1 are not compatible even with preprint DOI."""
-        assert _are_years_compatible(2024, 2026, "10.48550/arXiv.123", "10.1038/x") is False
-
-
-class TestIsPreprintDoi:
-    """Unit tests for the _is_preprint_doi helper."""
-
-    def test_arxiv_doi_recognised_as_preprint(self):
-        assert _is_preprint_doi("10.48550/arxiv.1706.03762") is True
-
-    def test_biorxiv_doi_recognised_as_preprint(self):
-        assert _is_preprint_doi("10.1101/2021.05.01.442244") is True
-
-    def test_ssrn_doi_recognised_as_preprint(self):
-        assert _is_preprint_doi("10.2139/ssrn.3844763") is True
-
-    def test_zenodo_doi_recognised_as_preprint(self):
-        assert _is_preprint_doi("10.5281/zenodo.18056028") is True
-
-    def test_publisher_doi_not_preprint(self):
-        assert _is_preprint_doi("10.5555/3295222.3295349") is False
-
-    def test_nature_doi_not_preprint(self):
-        assert _is_preprint_doi("10.1038/s41586-021-03819-2") is False
-
-    def test_case_insensitive(self):
-        assert _is_preprint_doi("10.48550/ARXIV.1706.03762") is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/utils/test_dedup.py
+++ b/tests/unit/utils/test_dedup.py
@@ -1,0 +1,68 @@
+"""Unit tests for utils.dedup"""
+
+from findpapers.utils.dedup import _are_years_compatible, _is_preprint_doi
+
+# ---------------------------------------------------------------------------
+# _are_years_compatible
+# ---------------------------------------------------------------------------
+
+
+class TestAreYearsCompatible:
+    """Tests for the extracted _are_years_compatible helper."""
+
+    def test_same_year_compatible(self) -> None:
+        """Identical years are always compatible."""
+        assert _are_years_compatible(2025, 2025, None, None) is True
+
+    def test_none_year_a_compatible(self) -> None:
+        """Unknown year_a makes pair compatible."""
+        assert _are_years_compatible(None, 2025, None, None) is True
+
+    def test_none_year_b_compatible(self) -> None:
+        """Unknown year_b makes pair compatible."""
+        assert _are_years_compatible(2025, None, None, None) is True
+
+    def test_both_none_compatible(self) -> None:
+        """Both years unknown is compatible."""
+        assert _are_years_compatible(None, None, None, None) is True
+
+    def test_different_years_no_doi_incompatible(self) -> None:
+        """Different years without DOIs are not compatible."""
+        assert _are_years_compatible(2024, 2025, None, None) is False
+
+    def test_different_years_non_preprint_doi_incompatible(self) -> None:
+        """Different years with non-preprint DOIs are not compatible."""
+        assert _are_years_compatible(2024, 2025, "10.1038/x", "10.1016/y") is False
+
+    def test_adjacent_year_preprint_doi_compatible(self) -> None:
+        """Adjacent years with a preprint DOI (arXiv) are compatible."""
+        assert _are_years_compatible(2025, 2026, "10.48550/arXiv.123", "10.1038/x") is True
+
+    def test_two_year_gap_preprint_incompatible(self) -> None:
+        """Years separated by >1 are not compatible even with preprint DOI."""
+        assert _are_years_compatible(2024, 2026, "10.48550/arXiv.123", "10.1038/x") is False
+
+
+class TestIsPreprintDoi:
+    """Unit tests for the _is_preprint_doi helper."""
+
+    def test_arxiv_doi_recognised_as_preprint(self):
+        assert _is_preprint_doi("10.48550/arxiv.1706.03762") is True
+
+    def test_biorxiv_doi_recognised_as_preprint(self):
+        assert _is_preprint_doi("10.1101/2021.05.01.442244") is True
+
+    def test_ssrn_doi_recognised_as_preprint(self):
+        assert _is_preprint_doi("10.2139/ssrn.3844763") is True
+
+    def test_zenodo_doi_recognised_as_preprint(self):
+        assert _is_preprint_doi("10.5281/zenodo.18056028") is True
+
+    def test_publisher_doi_not_preprint(self):
+        assert _is_preprint_doi("10.5555/3295222.3295349") is False
+
+    def test_nature_doi_not_preprint(self):
+        assert _is_preprint_doi("10.1038/s41586-021-03819-2") is False
+
+    def test_case_insensitive(self):
+        assert _is_preprint_doi("10.48550/ARXIV.1706.03762") is True


### PR DESCRIPTION
Adding the method merge_with to searchResult class

## Summary

Added the merge_with method to searchResult class, reorganized some minor code.


## Motivation

Allow workflow in the form of:

```
my_previous_search = findpapers.load_from_json("search_result_previous.json")
my_new_search = findpapers.load_from_json("search_result_new.json")
merge = my_previous_search.merge_with(my_new_search)
````

## Changes

- Added the merge_with method to searchResult
- Added test code for the new method
- `_deduplicate_and_merge` becomes a searchResult method that is called in search
- added a copy method to searchResult
- `creation of utils/dedup.py` with minor functions
- `title_year_key` becomes a method of Paper
- reorganization of tests
- deduplication tests in search_result

## How to test

All the test are in tests files.
For other tests use the workflow below with any searchResult

## Checklist

### Required
- [X ] **Label/type** is set (one of: feat | fix | perf | docs | test | chore)
- [ X] **CI passes** (all required checks green)
- [X ] **No secrets or credentials committed**

### Recommended / If applicable
- [X ] Tests added / updated (required for code changes)
- [ ] Documentation updated (README / docs) (if public API or user-facing changes)

---

I did not find how to generate the api-reference automatically. Can update manually if needed.
