### PR TITLE
fix: upgrade urllib3 to 2.7.0 (CVE-2026-44431, CVE-2026-44432)

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1731,14 +1731,14 @@ files = [
 
 [[package]]
 name = "urllib3"
-version = "2.6.3"
+version = "2.7.0"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4"},
-    {file = "urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed"},
+    {file = "urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"},
+    {file = "urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c"},
 ]
 
 [package.extras]
@@ -1779,4 +1779,4 @@ requests = ">=2.0,<3.0"
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "d982cdeb66232b0f38f46d7f9256a6806a71f7f466ca8c095589857c04551a15"
+content-hash = "4a9b45de0b55edf442482219b0110dc2c827c9a9e279ff70e9d08b4672d64e4f"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requests = "^2.32.0"
 curl-cffi = ">=0.15.0"
 tqdm = "^4.67.0"
 defusedxml = "^0.7.0"
+urllib3 = ">=2.7.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^9.0.3"


### PR DESCRIPTION
## Security fix

Bumps `urllib3` from `2.6.3` to `2.7.0` to address two High-severity CVEs reported by Dependabot (alerts #16 and #17).

### CVE-2026-44431 — Sensitive headers forwarded in proxied low-level redirects (High 8.2)
**Advisory:** [GHSA-qccp-gfcp-xxvc](https://github.com/urllib3/urllib3/security/advisories/GHSA-qccp-gfcp-xxvc)

When following cross-origin redirects via `ProxyManager.connection_from_url().urlopen(..., assert_same_host=False)`, sensitive headers (`Authorization`, `Cookie`, `Proxy-Authorization`) were not stripped. Fixed in 2.7.0.

### CVE-2026-44432 — Decompression-bomb safeguards bypassed in streaming API (High 8.9)
**Advisory:** [GHSA-mf9v-mfxr-j63j](https://github.com/urllib3/urllib3/security/advisories/GHSA-mf9v-mfxr-j63j)

When using the streaming API with Brotli-encoded responses or calling `HTTPResponse.drain_conn()` after partial decompression, the full response could be decompressed in one operation, causing excessive CPU/memory usage (CWE-409). Fixed in 2.7.0.

### Changes
- Added explicit `urllib3 = ">=2.7.0"` constraint to `pyproject.toml`
- Updated `poetry.lock` to pin `urllib3 2.7.0`

### Verification
- `pip-audit` confirms no urllib3 CVEs remain after the upgrade
- All 1911 unit tests pass (95% coverage)